### PR TITLE
Use type aliases for members

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -45,7 +45,7 @@ dotnet_style_qualification_for_method = false:warning
 dotnet_style_qualification_for_event = false:warning
 
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = false:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
 
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
 dotnet_style_readonly_field = true:suggestion


### PR DESCRIPTION
I don't know why this was set to false. This is the documentation:
https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#dotnet_style_predefined_type_for_member_access